### PR TITLE
Fix session cast starting value

### DIFF
--- a/ProcTracker.lua
+++ b/ProcTracker.lua
@@ -1,0 +1,85 @@
+local ProcTracker = CreateFrame("Frame")
+
+-- Some client versions use different spell IDs for Aura of the Blue Dragon.
+-- 23684 is used on Classic clients while retail clients can report 1213422.
+local BLUE_DRAGON_AURA_IDS = {
+    [23684] = true,
+    [1213422] = true,
+}
+
+ProcTracker.sessionCasts = 0
+ProcTracker.sessionProcs = 0
+ProcTracker.initialized = false
+ProcTracker.ignoreFirstCast = false
+
+-- Table storing information for each instance entered during the current session
+-- { zone = string, casts = number, procs = number }
+ProcTracker.instances = {}
+
+-- Holds the table of the instance the player is currently in, or nil when
+-- outside of an instance.
+ProcTracker.currentInstance = nil
+
+ProcTracker.inInstance = false
+ProcTracker.currentZone = nil
+
+local function StartNewInstance(zone)
+    local data = { zone = zone or "Unknown", casts = 0, procs = 0 }
+    table.insert(ProcTracker.instances, data)
+    ProcTracker.currentInstance = data
+end
+
+ProcTracker:RegisterEvent("UNIT_SPELLCAST_SUCCEEDED")
+ProcTracker:RegisterEvent("COMBAT_LOG_EVENT_UNFILTERED")
+ProcTracker:RegisterEvent("PLAYER_ENTERING_WORLD")
+
+ProcTracker:SetScript("OnEvent", function(self, event, ...)
+    if event == "UNIT_SPELLCAST_SUCCEEDED" then
+        local unit = ...
+        if unit == "player" then
+            if ProcTracker.ignoreFirstCast then
+                ProcTracker.ignoreFirstCast = false
+            else
+                ProcTracker.sessionCasts = ProcTracker.sessionCasts + 1
+                if ProcTracker.currentInstance then
+                    ProcTracker.currentInstance.casts = ProcTracker.currentInstance.casts + 1
+                end
+            end
+        end
+    elseif event == "COMBAT_LOG_EVENT_UNFILTERED" then
+        local timestamp, subevent, _, sourceGUID, sourceName, _, _, destGUID, destName, _, _, spellId = CombatLogGetCurrentEventInfo()
+        if subevent == "SPELL_AURA_APPLIED" and BLUE_DRAGON_AURA_IDS[spellId] and destGUID == UnitGUID("player") then
+            ProcTracker.sessionProcs = ProcTracker.sessionProcs + 1
+            if ProcTracker.currentInstance then
+                ProcTracker.currentInstance.procs = ProcTracker.currentInstance.procs + 1
+            end
+        end
+    elseif event == "PLAYER_ENTERING_WORLD" then
+        local inInstance = IsInInstance()
+        local zone = GetRealZoneText()
+        if not ProcTracker.initialized then
+            ProcTracker.sessionCasts = 0
+            ProcTracker.sessionProcs = 0
+            ProcTracker.ignoreFirstCast = true
+            ProcTracker.initialized = true
+        end
+        if inInstance then
+            if not ProcTracker.inInstance or zone ~= ProcTracker.currentZone then
+                StartNewInstance(zone)
+            end
+            ProcTracker.inInstance = true
+        else
+            ProcTracker.inInstance = false
+            ProcTracker.currentInstance = nil
+        end
+        ProcTracker.currentZone = zone
+    end
+end)
+
+SLASH_PROCTRACKER1 = "/proctracker"
+SlashCmdList["PROCTRACKER"] = function(msg)
+    print(string.format("Session Casts: %d, Session Procs: %d", ProcTracker.sessionCasts, ProcTracker.sessionProcs))
+    for i, inst in ipairs(ProcTracker.instances) do
+        print(string.format("Instance %d (%s): Casts: %d, Procs: %d", i, inst.zone, inst.casts, inst.procs))
+    end
+end

--- a/ProcTracker.toc
+++ b/ProcTracker.toc
@@ -1,0 +1,6 @@
+## Interface: 11400
+## Title: ProcTracker
+## Notes: Tracks Darkmoon Card: Blue Dragon procs.
+## Author: OpenAI
+## Version: 0.2
+ProcTracker.lua

--- a/README.md
+++ b/README.md
@@ -1,2 +1,10 @@
 # ProcTracker
-Addon to track trinket proc's
+
+WoW Classic addon to track Darkmoon Card: Blue Dragon procs.
+
+## Usage
+1. Copy the addon folder to your `Interface/AddOns` directory.
+2. In game, use `/proctracker` to print statistics about your session and each instance you have completed:
+   - number of successful spell casts
+   - number of times the trinket proc'd and granted **Aura of the Blue Dragon**
+   - summary of each instance run during this session


### PR DESCRIPTION
## Summary
- ignore the initial `UNIT_SPELLCAST_SUCCEEDED` so session casts start at zero

## Testing
- `luac -p ProcTracker.lua` *(fails: command not found)*
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6848165277c883289c0925f333ae1684